### PR TITLE
Wercker fix, update meta files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+requirements*.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -47,14 +48,6 @@ coverage.xml
 # Translations
 *.mo
 *.pot
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
 
 # Django stuff:
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ script:
 
 after_success:
   - mv tests/.coverage .
-  - codecov
+  - codecov || true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,0 @@
--r requirements.txt
-docopt
-pygments
-pytest-cov
-terminaltables

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 """Setup script for the project."""
 
-import atexit
 import codecs
 import os
 import re
-import subprocess
-import sys
-from distutils.spawn import find_executable
 
 import setuptools
-from setuptools.command.test import test
 
 _PACKAGES = lambda: [os.path.join(r, s) for r, d, _ in os.walk(NAME_FILE) for s in d if s != '__pycache__']
 _VERSION_RE = re.compile(r"^__(version|author|license)__ = '([\w\.@]+)'$", re.MULTILINE)
@@ -35,17 +30,10 @@ KEYWORDS = 'netlink libnl libnl-genl nl80211'
 NAME = 'libnl'
 NAME_FILE = NAME
 PACKAGE = True
+REQUIRES_INSTALL = []
+REQUIRES_TEST = ['docopt', 'pygments', 'pytest-cov', 'terminaltables']
+REQUIRES_ALL = REQUIRES_INSTALL + REQUIRES_TEST
 VERSION_FILE = os.path.join(NAME_FILE, '__init__.py') if PACKAGE else '{0}.py'.format(NAME_FILE)
-
-
-def _requires(path):
-    """Read requirements file."""
-    if not os.path.exists(os.path.join(HERE, path)):
-        return list()
-    file_handle = codecs.open(os.path.join(HERE, path), encoding='utf-8')
-    requirements = [i.strip() for i in file_handle if i[0] != '-']
-    file_handle.close()
-    return requirements
 
 
 def _safe_read(path, length):
@@ -58,62 +46,16 @@ def _safe_read(path, length):
     return contents
 
 
-class PyTest(test):
-    """Run tests with pytest."""
-
-    description = 'Run all tests.'
-    user_options = []
-    CMD = 'test'
-    TEST_ARGS = ['--cov-report', 'term-missing', '--cov', NAME_FILE, 'tests']
-
-    def finalize_options(self):
-        """Finalize options."""
-        overflow_args = sys.argv[sys.argv.index(self.CMD) + 1:]
-        test.finalize_options(self)
-        setattr(self, 'test_args', self.TEST_ARGS + overflow_args)
-        setattr(self, 'test_suite', True)
-
-    def run_tests(self):
-        """Run the tests."""
-        # Import here, cause outside the eggs aren't loaded.
-        pytest = __import__('pytest')
-        err_no = pytest.main(self.test_args)
-        sys.exit(err_no)
-
-
-class PyTestPdb(PyTest):
-    """Run tests with pytest and drop to debugger on test failure/errors."""
-
-    _ipdb = 'ipdb' if sys.version_info[:2] > (2, 6) else 'pdb'
-    description = 'Run all tests, drops to {0} upon unhandled exception.'.format(_ipdb)
-    CMD = 'testpdb'
-    TEST_ARGS = ['--{0}'.format(_ipdb), 'tests']
-
-
-class PyTestCovWeb(PyTest):
-    """Run the tests and open a web browser (OS X only) showing coverage information."""
-
-    description = 'Generates HTML report on test coverage.'
-    CMD = 'testcovweb'
-    TEST_ARGS = ['--cov-report', 'html', '--cov', NAME_FILE, 'tests']
-
-    def run_tests(self):
-        """Run the tests and then open."""
-        if find_executable('open'):
-            atexit.register(lambda: subprocess.call(['open', os.path.join(HERE, 'htmlcov', 'index.html')]))
-        PyTest.run_tests(self)
-
-
 ALL_DATA = dict(
     author_email='robpol86@gmail.com',
     classifiers=CLASSIFIERS,
-    cmdclass={PyTest.CMD: PyTest, PyTestPdb.CMD: PyTestPdb, PyTestCovWeb.CMD: PyTestCovWeb},
     description=DESCRIPTION,
-    install_requires=_requires('requirements.txt'),
+    install_requires=REQUIRES_INSTALL,
     keywords=KEYWORDS,
     long_description=_safe_read('README.rst', 15000),
     name=NAME,
-    tests_require=_requires('requirements-test.txt'),
+    requires=REQUIRES_INSTALL,
+    tests_require=REQUIRES_TEST,
     url='https://github.com/Robpol86/{0}'.format(NAME),
     zip_safe=True,
 )
@@ -122,7 +64,6 @@ ALL_DATA = dict(
 # noinspection PyTypeChecker
 ALL_DATA.update(dict(_VERSION_RE.findall(_safe_read(VERSION_FILE, 1500).replace('\r\n', '\n'))))
 ALL_DATA.update(dict(py_modules=[NAME_FILE]) if not PACKAGE else dict(packages=[NAME_FILE] + _PACKAGES()))
-ALL_DATA['requires'] = ALL_DATA['install_requires']
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,21 @@
 [tox]
-envlist = flake8,check,py{34,33,py3,py,27,26}
+envlist = flake8,check,requirements,py{34,33,py3,py,27,26}
 skip_missing_interpreters = True
 
 [testenv]
 commands =
-    python setup.py test{posargs}
-    mv .coverage tests/.coverage.{envname}
+    py.test --cov-report term-missing --cov libnl tests {posargs}
+    python -c "import os, shutil; shutil.move('.coverage', os.path.join('tests', '.coverage.{envname}'))"
 deps =
     -rrequirements-test.txt
-    py{34,33,py,27},py{34,33,27}x64: robpol86-pytest-ipdb
-whitelist_externals = mv
+usedevelop = True
+
+[testenv:requirements]
+basepython = python3.4
+commands =
+    python -c "import setup; open('requirements-test.txt', 'w').write('\n'.join(setup.REQUIRES_ALL))"
+    python -c "open('requirements-test.txt', 'a').write('\npdbpp==0.8.1') if '--pdb' in '{posargs}' else None"
+deps =
 
 [testenv:combine]
 basepython = python3.4
@@ -25,6 +31,7 @@ commands =
     python setup.py check --strict
     python setup.py check --strict -m
     python setup.py check --strict -s
+deps =
 
 [testenv:pylint]
 basepython = python3.4
@@ -36,7 +43,7 @@ basepython = python3.4
 commands = flake8
 deps =
     flake8
-    flake8-import-order
+    flake8-import-order==0.5
     flake8-pep257
 
 [flake8]

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,8 +13,10 @@ build:
         code: |
             sudo add-apt-repository -y ppa:fkrull/deadsnakes
             sudo add-apt-repository -y ppa:pypy/ppa
-            sudo apt-get update -y
-            sudo apt-get install -y python-pip python3.4 python2.6 pypy
+            sudo apt-get update -y || true
+            sudo apt-get install -y python3.4 python2.6 pypy
+            wget https://bootstrap.pypa.io/get-pip.py
+            sudo python get-pip.py
             sudo pip install codecov tox
 
     - script:
@@ -27,4 +29,4 @@ build:
         name: YAML - Coverage
         code: |
             mv tests/.coverage .
-            codecov
+            codecov || true


### PR DESCRIPTION
Wercker box used by libnl is outdated and cannot apt-get update anymore
(distro no longer in ubuntu's repo apparently). However I don't use any
of those packages, I just need the python stuff. So the fix is to "||
true" the command. Also got some weird package signing issues, using
get-pip.py instead.

Updated meta files to use the same ones in my other projects.

Moving requirements to setup.py file instead of external requirements
files.

Moving pdb/etc commands from setup.py into tox.

Pinning flake8-import-order since the latest version has a bug.

Using pdbpp instead of ipdb.

For some reason codecov isn't working in pull requests. Working around
this for now.